### PR TITLE
Source base AMI from configuration file

### DIFF
--- a/aws/aws_deployment.go
+++ b/aws/aws_deployment.go
@@ -305,7 +305,7 @@ func GetPlugin() sdutils.Plugin {
 		AmiID:          "",
 		AwsKeyName:     "",
 		ZkInstanceType: "t2.small",
-		SdInstanceType: "m3.medium",
+		SdInstanceType: "t2.medium",
 		BastionType:    "t2.small",
 		VolumeType:     "gp2",
 		IoPs:           0,

--- a/aws/aws_instance.go
+++ b/aws/aws_instance.go
@@ -122,6 +122,27 @@ func volumeLineScanner(cliContext sdutils.AppContext, line string) *sdutils.Scan
 	return nil
 }
 
+// func (awsI *Ec2Instance) runTerraformInit() error {
+// 	terraformPath, err := exec.LookPath("terraform")
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	cmdArray := []string{terraformPath, "init"}
+// 	cmd := exec.Cmd{
+// 		Path: cmdArray[0],
+// 		Args: cmdArray,
+// 		Dir:  instanceWorkingDir,
+// 	}
+// 	awsI.Ctx.Logf(sdutils.INFO, "Running terraform init...\n")
+// 	spin := sdutils.NewSpinner(awsI.Ctx, 1, message)
+// 	_, err = sdutils.RunCommand(awsI.Ctx, cmd, volumeLineScanner, spin)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }
+
 func (awsI *Ec2Instance) runTerraformApply(volumeSize int, zookeeperSize int, mask string, idleTimeout int, message string) error {
 	awsI.ZkSize = fmt.Sprintf("%d", zookeeperSize)
 	awsI.ELBIdleTimeout = fmt.Sprintf("%d", idleTimeout)

--- a/aws/etc/packer/scripts/cleanup.sh
+++ b/aws/etc/packer/scripts/cleanup.sh
@@ -8,6 +8,12 @@ rm /var/lib/dhcp/*
 
 echo "cleaning up udev rules"
 rm -rf /etc/udev/rules.d/70-persistent-net.rules
-mkdir -p /etc/udev/rules.d/70-persistent-net.rules
 rm -rf /dev/.udev/
 rm -f /lib/udev/rules.d/75-persistent-net-generator.rules
+
+set -e
+echo "Cleaning up cloud-init data..."
+rm -rf /var/lib/cloud/instances
+rm -rf /var/lib/cloud/instance
+rm -f /home/ubuntu/.ssh/authorized_keys
+rm -f /var/log/cloud-init*

--- a/aws/etc/packer/stardog.json
+++ b/aws/etc/packer/stardog.json
@@ -11,7 +11,7 @@
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "{{user `region`}}",
     "source_ami": "{{user `source_ami`}}",
-    "instance_type": "c3.2xlarge",
+    "instance_type": "c4.large",
     "ssh_username": "ubuntu",
     "ami_name": "stardog {{user `version`}} {{timestamp}}",
     "ami_description": "stardog graviton virtual appliance base ami {{user `version`}} {{timestamp}}",

--- a/aws/etc/packer/tools/python/stardog/cluster/find_volume.py
+++ b/aws/etc/packer/tools/python/stardog/cluster/find_volume.py
@@ -5,8 +5,8 @@ import sys
 import stardog.cluster.utils as utils
 
 
-def find_mount_iteration(deployment_name, device, instance_id):
-    volume_id = utils.find_volume(deployment_name)
+def find_mount_iteration(deployment_name, device, instance_id, az):
+    volume_id = utils.find_volume(deployment_name, az=az)
     if volume_id is None:
         return False
     logging.debug("Attaching the volume %s..." % volume_id)
@@ -72,7 +72,7 @@ def main():
         device = sys.argv[3]
 
         def find_attach_it():
-            return find_mount_iteration(deployment_name, device, instance_id)
+            return find_mount_iteration(deployment_name, device, instance_id, az)
         rc = utils.wait_for_func(10, 5, find_attach_it)
         if not rc:
             e_msg = "Failed to attach the volume in the given number of tries"

--- a/aws/etc/packer/tools/python/stardog/cluster/utils.py
+++ b/aws/etc/packer/tools/python/stardog/cluster/utils.py
@@ -36,9 +36,11 @@ def run_json_command(cmd):
     return True, d
 
 
-def find_volume(deployment_name):
+def find_volume(deployment_name, az=None):
     logging.debug("attempting to find an available volume for %s" % deployment_name)
     cmd = 'aws ec2 describe-volumes --filters Name=status,Values=available Name=tag-key,Values="DeploymentName" Name=tag-value,Values=%s' % deployment_name
+    if az is not None:
+        cmd = "%s Name=availability-zone,Values=%s" % (cmd, az)
     rc, vols = run_json_command(cmd)
     if not rc:
         logging.warning("A volume was not found for %s" % deployment_name)

--- a/aws/etc/terraform/instance/bastion.tf
+++ b/aws/etc/terraform/instance/bastion.tf
@@ -15,6 +15,11 @@ resource "aws_autoscaling_group" "bastion" {
     value = "${var.deployment_name}"
     propagate_at_launch = true
   }
+  tag {
+    key = "Name"
+    value = "BastionNode"
+    propagate_at_launch = true
+  }
 }
 
 resource "aws_launch_configuration" "bastion" {

--- a/aws/etc/terraform/instance/stardog.tf
+++ b/aws/etc/terraform/instance/stardog.tf
@@ -42,6 +42,11 @@ resource "aws_autoscaling_group" "stardog" {
     value = "${var.deployment_name}"
     propagate_at_launch = true
   }
+  tag {
+    key = "Name"
+    value = "StardogNode"
+    propagate_at_launch = true
+  }
 }
 
 resource "aws_launch_configuration" "stardog" {
@@ -52,7 +57,6 @@ resource "aws_launch_configuration" "stardog" {
   key_name = "${var.aws_key_name}"
   security_groups = ["${aws_security_group.stardog.id}"]
   iam_instance_profile = "${aws_iam_instance_profile.stardog.id}"
-  # XXX TODO figure out why we need a public ip for external routing
   associate_public_ip_address = true
 
   root_block_device {

--- a/aws/etc/terraform/instance/variables.tf
+++ b/aws/etc/terraform/instance/variables.tf
@@ -10,7 +10,7 @@ variable "stardog_instance_type" {
 
 variable "bastion_instance_type" {
   type = "string"
-  default = "m3.medium"
+  default = "t2.medium"
   description = "The AWS instance type for stardog."
 }
 
@@ -54,7 +54,7 @@ variable "aws_az" {
       "us-east-2c"]
     us-west-1 = [
       "us-west-1a",
-      "us-west-1c"]
+      "us-west-1b"]
     us-west-2 = [
       "us-west-2a",
       "us-west-2b",
@@ -67,7 +67,31 @@ variable "aws_az" {
       "eu-west-1a",
       "eu-west-1b",
       "eu-west-1c"
-    ]
+    ],
+    eu-west-2 = [
+      "eu-west-2a",
+      "eu-west-2b"
+    ],
+    ap-northeast-1 = [
+      "ap-northeast-1a",
+      "ap-northeast-1c"
+    ],
+    ap-northeast-2 = [
+      "ap-northeast-2a",
+      "ap-northeast-2c"
+    ],
+    ap-southeast-1 = [
+      "ap-southeast-1a",
+      "ap-southeast-1b"
+    ],
+    ap-southeast-2 = [
+      "ap-southeast-2a",
+      "ap-southeast-2b"
+    ],
+    sa-east-1 = [
+      "sa-east-1a",
+      "sa-east-1c"
+    ],
   }
 }
 

--- a/aws/etc/terraform/instance/zookeeper.tf
+++ b/aws/etc/terraform/instance/zookeeper.tf
@@ -51,6 +51,11 @@ resource "aws_autoscaling_group" "zookeeper" {
     value = "${var.deployment_name}"
     propagate_at_launch = true
   }
+    tag {
+    key = "Name"
+    value = "ZookeeperNode"
+    propagate_at_launch = true
+  }
 }
 
 resource "aws_launch_configuration" "zookeeper" {

--- a/aws/etc/terraform/volumes/variables.tf
+++ b/aws/etc/terraform/volumes/variables.tf
@@ -29,7 +29,7 @@ variable "aws_az" {
       "us-east-2c"]
     us-west-1 = [
       "us-west-1a",
-      "us-west-1c"]
+      "us-west-1b"]
     us-west-2 = [
       "us-west-2a",
       "us-west-2b",
@@ -42,7 +42,32 @@ variable "aws_az" {
       "eu-west-1a",
       "eu-west-1b",
       "eu-west-1c"
-    ]
+    ],
+    eu-west-2 = [
+      "eu-west-2a",
+      "eu-west-2b"
+    ],
+    ap-northeast-1 = [
+      "ap-northeast-1a",
+      "ap-northeast-1c"
+    ],
+    ap-northeast-2 = [
+      "ap-northeast-2a",
+      "ap-northeast-2c"
+    ],
+    ap-southeast-1 = [
+      "ap-southeast-1a",
+      "ap-southeast-1b"
+    ],
+    ap-southeast-2 = [
+      "ap-southeast-2a",
+      "ap-southeast-2b",
+      "ap-southeast-2c"
+    ],
+    sa-east-1 = [
+      "sa-east-1a",
+      "sa-east-1c"
+    ],
   }
 }
 

--- a/ci/run_grav.py
+++ b/ci/run_grav.py
@@ -1,0 +1,55 @@
+import json
+import os
+import subprocess
+import threading
+
+_g_failed = []
+_g_lock = threading.Lock()
+
+_run_count = 2
+
+
+def run_region(region):
+    try:
+        deploy_name = "bz%d%s" % (_run_count, region.replace("-", ""))
+        cmd = "~/go/bin/stardog-graviton launch --force --region %s %s" % (region, deploy_name)
+        p = subprocess.Popen(cmd, shell=True)
+        out, err = p.communicate()
+        prc = p.wait()
+        if prc != 0:
+            with _g_lock:
+                _g_failed.append(region + " failed to start " + deploy_name)
+            print("%s failed %d" % (region, prc))
+            return
+
+        cmd = "~/go/bin/stardog-graviton destroy --force %s" % deploy_name
+        p = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE)
+        out, err = p.communicate()
+        prc = p.wait()
+        if prc != 0:
+            with _g_lock:
+                _g_failed.append(region + " NOT DESTROYED!")
+            print("%s failed" % region)
+            print(err)
+    except Exception as ex:
+        with _g_lock:
+            _g_failed.append(region + "WITH EXCEPTION")
+
+
+
+with open(os.path.expanduser("~/.graviton/base-amis-5.0.2.json")) as fptr:
+    d = json.load(fptr)
+
+zones = ["ap-northeast-1", "ap-southeast-2"]
+thread_list = []
+for r in d.keys():
+    print(r)
+    t = threading.Thread(target=run_region, args=(r,))
+    thread_list.append(t)
+    t.start()
+
+for t in thread_list:
+    t.join()
+
+for f in _g_failed:
+    print("%s failed" % f)

--- a/release/smoke_test_1.py
+++ b/release/smoke_test_1.py
@@ -103,7 +103,7 @@ def make_defaults_file(working_dir, sd_license, release_full_path, release_name,
         "cloud_options": {
             "region": "us-west-1",
             "zk_instance_type": "t2.small",
-            "sd_instance_type": "m3.medium",
+            "sd_instance_type": "t2.medium",
             "aws_key_name": ssh_key_name
         }
     }


### PR DESCRIPTION
Instead of having the base AMIs that are used to build the Stardog
AMIs baked into the code we will get them from a configuration file
~/.graviton/base-amis-<sd version>.json.  If that file is not found
it is created from the values originally baked into the code.  This
gives users a chance to override and update those values.  This patch
also updates the default base AMI to Ubuntu 16.04 hvm.