### PR TITLE
Adding in version control fro dependent executables

### DIFF
--- a/aws/aws_buildimage.go
+++ b/aws/aws_buildimage.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/stardog-union/stardog-graviton/sdutils"
+	"runtime"
 )
 
 var (
@@ -96,6 +97,11 @@ func (a *awsPlugin) BuildImage(context sdutils.AppContext, sdReleaseFilePath str
 			return fmt.Errorf("The environment variable %s must be set", e)
 		}
 	}
+	packerURL := fmt.Sprintf("https://releases.hashicorp.com/packer/%s/packer_%s_%s_%s.zip", PackerVersion, PackerVersion, runtime.GOOS, runtime.GOARCH)
+	err := sdutils.FindProgramVersion(context, "packer", PackerVersion, packerURL)
+	if err != nil {
+		return fmt.Errorf("We could not get a proper version of packer %s", err.Error())
+	}
 
 	context.Logf(sdutils.DEBUG, "Place assets\n")
 
@@ -107,7 +113,7 @@ func (a *awsPlugin) BuildImage(context sdutils.AppContext, sdReleaseFilePath str
 	context.ConsoleLog(2, "Extracting packer files to: %s\n", dir)
 	defer os.RemoveAll(dir)
 
-	packerPath, err := exec.LookPath("packer")
+	packerPath, err := GetPackerPath(context)
 	if err != nil {
 		return err
 	}

--- a/aws/aws_deployment_test.go
+++ b/aws/aws_deployment_test.go
@@ -112,50 +112,6 @@ func TestDeploymentLoadEnvs(t *testing.T) {
 	}
 }
 
-func TestDeploymentLoadNoExes(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "stardogtest")
-	defer os.RemoveAll(dir)
-	sshKeyFile := path.Join(dir, "keyfile")
-	fakeOut := "xxx"
-	ioutil.WriteFile(sshKeyFile, []byte(fakeOut), 0600)
-
-	plugin := &awsPlugin{
-		Region:         "us-west-1",
-		AmiID:          "notreal",
-		AwsKeyName:     "somekey",
-		ZkInstanceType: "m3.large",
-		SdInstanceType: "m3.large",
-		VolumeType:     "gp2",
-	}
-	app := sdutils.TestContext{
-		ConfigDir: dir,
-		Version:   "4.2",
-	}
-
-	keySave := os.Getenv("AWS_ACCESS_KEY_ID")
-	defer os.Setenv("AWS_ACCESS_KEY_ID", keySave)
-	os.Setenv("AWS_ACCESS_KEY_ID", "gravitontest")
-	secretSave := os.Getenv("AWS_SECRET_ACCESS_KEY")
-	defer os.Setenv("AWS_SECRET_ACCESS_KEY", secretSave)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "somesecret")
-
-	sPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", sPath)
-	os.Setenv("PATH", "/")
-
-	baseD := sdutils.BaseDeployment{
-		Type:       plugin.GetName(),
-		Name:       "testdep",
-		Directory:  dir,
-		Version:    "4.2",
-		PrivateKey: sshKeyFile,
-	}
-	_, err := plugin.DeploymentLoader(&app, &baseD, true)
-	if err == nil {
-		t.Fatalf("The deployment should have failed")
-	}
-}
-
 func TestDeploymentLoadNew(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "stardogtest")
 	defer os.RemoveAll(dir)
@@ -183,12 +139,12 @@ func TestDeploymentLoadNew(t *testing.T) {
 	defer os.Setenv("AWS_SECRET_ACCESS_KEY", secretSave)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "gravitontest")
 
-	exedirT, _, err := CreateTestExec("terraform", "data", 0)
+	exedirT, _, err := MakeTestTerraform(0, "data", "")
 	if err != nil {
 		t.Fatalf("Failed to write the file %s", err)
 	}
 	defer os.RemoveAll(exedirT)
-	exedirP, _, err := CreateTestExec("packer", "data", 0)
+	exedirP, _, err := MakeTestPacker(0, "data", "")
 	if err != nil {
 		t.Fatalf("Failed to write the file %s", err)
 	}

--- a/aws/aws_instance.go
+++ b/aws/aws_instance.go
@@ -123,7 +123,7 @@ func volumeLineScanner(cliContext sdutils.AppContext, line string) *sdutils.Scan
 }
 
 // func (awsI *Ec2Instance) runTerraformInit() error {
-// 	terraformPath, err := exec.LookPath("terraform")
+// 	terraformPath, err := GetTerraformPath(awsI.Ctx)
 // 	if err != nil {
 // 		return err
 // 	}
@@ -168,7 +168,7 @@ func (awsI *Ec2Instance) runTerraformApply(volumeSize int, zookeeperSize int, ma
 		return err
 	}
 
-	terraformPath, err := exec.LookPath("terraform")
+	terraformPath, err := GetTerraformPath(awsI.Ctx)
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func (awsI *Ec2Instance) DeleteInstance() error {
 	if !sdutils.PathExists(instanceConfPath) {
 		return fmt.Errorf("There is no configured instance")
 	}
-	terraformPath, err := exec.LookPath("terraform")
+	terraformPath, err := GetTerraformPath(awsI.Ctx)
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func getInstanceValues(awsI *Ec2Instance) (*InstanceStatusDescription, error) {
 	if !sdutils.PathExists(instanceConfPath) {
 		return nil, fmt.Errorf("There is no configured instance")
 	}
-	terraformPath, err := exec.LookPath("terraform")
+	terraformPath, err := GetTerraformPath(awsI.Ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/aws_instance_test.go
+++ b/aws/aws_instance_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stardog-union/stardog-graviton/sdutils"
+	"fmt"
 )
 
 func TestInstanceNotThere(t *testing.T) {
@@ -156,16 +157,18 @@ func TestInstanceFakeTerraform(t *testing.T) {
 
 	startPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", startPath)
-	exedir, _, err := CreateTestExec("terraform", data, 0)
+	exedir, _, err := MakeTestTerraform(0, data, dir)
 	if err != nil {
 		t.Fatalf("Failed to write the file %s", err)
 	}
 	defer os.RemoveAll(exedir)
+	newPath := fmt.Sprintf("%s:%s", exedir, startPath)
+	err = os.Setenv("PATH", newPath)
 
 	ebs := NewAwsEbsVolumeManager(&app, dd)
 	err = ebs.CreateSet("/path/", 1, 3)
 	if err != nil {
-		t.Fatalf("The create should have worked")
+		t.Fatalf("The create should have worked %s", err)
 	}
 
 	err = inst.CreateInstance(8, 1, 60)
@@ -253,7 +256,7 @@ func TestInstanceFakeTerraformThroughDeployment(t *testing.T) {
 
 	startPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", startPath)
-	exedir, _, err := CreateTestExec("terraform", data, 0)
+	exedir, _, err := MakeTestTerraform(0, data, dir)
 	if err != nil {
 		t.Fatalf("Failed to write the file %s", err)
 	}

--- a/aws/aws_volumes.go
+++ b/aws/aws_volumes.go
@@ -91,7 +91,7 @@ func (v *EbsVolumes) VolumeExists() bool {
 func (v *EbsVolumes) CreateSet(licensePath string, sizeOfEachVolume int, clusterSize int) error {
 	// TODO make sure we clean up resources on failure
 	v.appContext.ConsoleLog(2, "Creating an aws volume set in directory %s\n", v.VolumeDir)
-	terraformPath, err := exec.LookPath("terraform")
+	terraformPath, err := GetTerraformPath(v.appContext)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func (v *EbsVolumes) CreateSet(licensePath string, sizeOfEachVolume int, cluster
 // DeleteSet will delete the EBS volumes from AWS.
 func (v *EbsVolumes) DeleteSet() error {
 	confFile := path.Join(v.VolumeDir, "config.json")
-	terraformPath, err := exec.LookPath("terraform")
+	terraformPath, err := GetTerraformPath(v.appContext)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func (v *EbsVolumes) DeleteSet() error {
 }
 
 func (v *EbsVolumes) getStatusInformation() (*VolumeStatusDescription, error) {
-	terraformPath, err := exec.LookPath("terraform")
+	terraformPath, err := GetTerraformPath(v.appContext)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/aws_volumes_test.go
+++ b/aws/aws_volumes_test.go
@@ -81,7 +81,7 @@ func TestVolumesNotThere(t *testing.T) {
 
 	startPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", startPath)
-	exedir, _, err := CreateTestExec("terraform", "data", 0)
+	exedir, _, err := MakeTestTerraform(0, "data", dir)
 	if err != nil {
 		t.Fatalf("Failed to write the file %s", err)
 	}
@@ -117,7 +117,7 @@ func TestVolumesNotThere(t *testing.T) {
 	}
 	// Add in good status
 	data := `{"volumes": { "sensitive": false, "type": "list", "value": ["vol-46313ce8", "vol-a34ba11c", "vol-50313cfe"]}}`
-	exedir2, _, err := CreateTestExec("terraform", data, 0)
+	exedir2, _, err := MakeTestTerraform(0, data, dir)
 	if err != nil {
 		t.Fatalf("Failed to write the file %s", err)
 	}
@@ -189,7 +189,7 @@ func TestVolumesThroughDD(t *testing.T) {
 
 	startPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", startPath)
-	exedir, _, err := CreateTestExec("terraform", "data", 0)
+	exedir, _, err := MakeTestTerraform(0, "data", dir)
 	if err != nil {
 		t.Fatalf("Failed to write the file %s", err)
 	}
@@ -225,7 +225,7 @@ func TestVolumesThroughDD(t *testing.T) {
 	}
 	// Add in good status
 	data := `{"volumes": { "sensitive": false, "type": "list", "value": ["vol-46313ce8", "vol-a34ba11c", "vol-50313cfe"]}}`
-	exedir2, _, err := CreateTestExec("terraform", data, 0)
+	exedir2, _, err := MakeTestTerraform(0, data, dir)
 	if err != nil {
 		t.Fatalf("Failed to write the file %s", err)
 	}

--- a/aws/etc/packer/stardog.json
+++ b/aws/etc/packer/stardog.json
@@ -13,7 +13,7 @@
     "source_ami": "{{user `source_ami`}}",
     "instance_type": "c4.large",
     "ssh_username": "ubuntu",
-    "ami_name": "stardog {{user `version`}} {{timestamp}}",
+    "ami_name": "stardog graviton {{user `version`}} {{timestamp}}",
     "ami_description": "stardog graviton virtual appliance base ami {{user `version`}} {{timestamp}}",
     "tags": {
       "OS_Version": "Ubuntu",

--- a/main.go
+++ b/main.go
@@ -605,6 +605,7 @@ func (cliContext *CliContext) topValidate(a *kingpin.Application) error {
 	}
 	logWriter, err := os.OpenFile(cliContext.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
+		fmt.Printf("COULDNT OPEN %s\n", cliContext.LogFilePath)
 		return fmt.Errorf("Could not open the file %s.  %s", cliContext.LogFilePath, err.Error())
 	}
 	cliContext.LogLevel = strings.ToUpper(cliContext.LogLevel)

--- a/sdutils/deployment.go
+++ b/sdutils/deployment.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -26,7 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"math/rand"
 )
 
 var (
@@ -88,9 +88,6 @@ func LoadDeployment(context AppContext, baseD *BaseDeployment, new bool) (Deploy
 	os.MkdirAll(baseD.Directory, 0755)
 
 	d, err := plugin.DeploymentLoader(context, baseD, new)
-	if err != nil {
-		os.RemoveAll(baseD.Directory)
-	}
 	return d, err
 }
 
@@ -297,8 +294,8 @@ func WaitForNClusterNodes(context AppContext, size int, sdURL string, pw string,
 	itCnt := waitTimeout / pollInterval
 
 	client := stardogClientImpl{
-		sdURL: sdURL,
-		logger: context,
+		sdURL:    sdURL,
+		logger:   context,
 		username: "admin",
 		password: pw,
 	}
@@ -446,8 +443,8 @@ func FullStatus(context AppContext, baseD *BaseDeployment, dep Deployment, inter
 	}
 
 	client := stardogClientImpl{
-		sdURL: sd.StardogURL,
-		logger: context,
+		sdURL:    sd.StardogURL,
+		logger:   context,
 		username: "admin",
 		password: pw,
 	}

--- a/sdutils/deployment_test.go
+++ b/sdutils/deployment_test.go
@@ -98,9 +98,6 @@ func TestLoadNewDeploymentFailLoad(t *testing.T) {
 	if err == nil {
 		t.Fatal("No deployment load should fail")
 	}
-	if PathExists(dir) {
-		t.Fatalf("The deployment directory should not be created when failure occurs. %s, %s", dir, err)
-	}
 }
 
 func TestLoadNewDeploymentGoodLoad(t *testing.T) {


### PR DESCRIPTION
graviton currently depends on two single file executables, terraform
and packer.  Both of these programs are single executables (waving
hands at some new weirdness in terraform) so they can be copied and
placed into ~/.graviton and thereby we can better control the versions
used on a given system.  Recently terraform had a breaking change
and thus users that upgraded terraform broke their graviton installation.

This patch locks down versions of terraform and packer to specfic releases.
It first looks for the executables under ~/.gravtion.  If they are there
and have the correct `--version` output then they are used.  Otherwise the
system path is searched.  If found it is copied to ~/.graviton.  Otherwise
They are downloaded from a known location.