### PR TITLE
Adding support for a custom script

### DIFF
--- a/aws/aws_buildimage.go
+++ b/aws/aws_buildimage.go
@@ -39,7 +39,7 @@ var (
 		"eu-central-1":   "ami-958128fa",
 		"us-east-1":      "ami-1d4e7a66",
 		"us-west-1":      "ami-969ab1f6",
-		"us-west-2":      "ami-8803e0f0",
+		"us-west-2":      "ami-0a00ce72",
 	}
 )
 

--- a/aws/aws_deployment.go
+++ b/aws/aws_deployment.go
@@ -41,6 +41,7 @@ type awsDeploymentDescription struct {
 	HTTPMask        string `json:"http_mask,omitempty"`
 	VolumeType      string `json:"volume_type,omitempty"`
 	IoPsRatio       int    `json:"iops,omitempty"`
+	CustomScript    string `json:"custom_script,omitempty"`
 	Version         string `json:"-"`
 	Name            string `json:"-"`
 	deployDir       string
@@ -375,6 +376,7 @@ func (a *awsPlugin) DeploymentLoader(context sdutils.AppContext, baseD *sdutils.
 		if err != nil {
 			return nil, err
 		}
+		awsDD.CustomScript = baseD.CustomScript
 		awsDD.environment = baseD.Environment
 		awsDD.disableSecurity = baseD.DisableSecurity
 		baseD.CloudOpts = awsDD

--- a/aws/etc/packer/stardog.json
+++ b/aws/etc/packer/stardog.json
@@ -11,7 +11,7 @@
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "{{user `region`}}",
     "source_ami": "{{user `source_ami`}}",
-    "instance_type": "c4.large",
+    "instance_type": "m3.medium",
     "ssh_username": "ubuntu",
     "ami_name": "stardog graviton {{user `version`}} {{timestamp}}",
     "ami_description": "stardog graviton virtual appliance base ami {{user `version`}} {{timestamp}}",

--- a/aws/etc/packer/tools/python/stardog/cluster/gather_log.py
+++ b/aws/etc/packer/tools/python/stardog/cluster/gather_log.py
@@ -1,29 +1,26 @@
 import os
-
 import logging
 import tarfile
 import tempfile
-import requests
-
 import subprocess
-
 import sys
 
-
-def get_cluster_doc(sd_url, pw):
-    full_url = sd_url + "/admin/cluster"
-    logging.info("Trying to contact %s" % full_url)
-    r = requests.get(sd_url + "/admin/cluster", auth=('admin', pw))
-    if r.status_code != 200:
-        raise Exception("Unable to get the cluster document %d" % r.status_code)
-    return r.json()
+import stardog.cluster.utils as utils
 
 
-def get_log(host, temp_dir, src_log):
-    name = os.path.basename(src_log)
-    dst_name = os.path.join(temp_dir, name + "." + host)
+def get_log(host, temp_dir, src_log, src_is_dir=False):
+    if src_is_dir:
+        name = os.path.basename(os.path.dirname(src_log))
+        dst_name = os.path.join(temp_dir, name + "." + host)
+        try:
+            os.makedirs(dst_name)
+        except OSError:
+            pass
+    else:
+        name = os.path.basename(src_log)
+        dst_name = os.path.join(temp_dir, name + "." + host)
     scp_opts = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-    cmd = "scp %s %s:%s %s" % (scp_opts, host, src_log, dst_name)
+    cmd = "scp -r %s %s:%s %s" % (scp_opts, host, src_log, dst_name)
     print(cmd)
     p = subprocess.Popen(cmd, shell=True, cwd=temp_dir)
     o, e = p.communicate()
@@ -37,11 +34,13 @@ def get_log(host, temp_dir, src_log):
 
 def get_all_logs(cluster_doc):
     dst_dir = tempfile.mkdtemp()
-
     logs_copied = 0
     for hp in cluster_doc['nodes']:
         ha = hp.split(':')
         b = get_log(ha[0], dst_dir, "/mnt/data/stardog-home/stardog.log")
+        if b:
+            logs_copied += 1
+        b = get_log(ha[0], dst_dir, "/mnt/data/stardog-home/logs/*", src_is_dir=True)
         if b:
             logs_copied += 1
     return logs_copied, dst_dir
@@ -56,11 +55,10 @@ def main():
     sd_url = sys.argv[1]
     dst_file = sys.argv[2]
     pw = sys.argv[3]
-    d = get_cluster_doc(sd_url, pw)
+    d = utils.get_cluster_doc(sd_url, pw)
     n, log_dir = get_all_logs(d)
     logging.info("Retrieved %d logs" % n)
     if n < 1:
         raise Exception("No logs were gathered")
     create_tarball(log_dir, dst_file)
     return 0
-

--- a/aws/etc/packer/tools/python/stardog/cluster/utils.py
+++ b/aws/etc/packer/tools/python/stardog/cluster/utils.py
@@ -3,12 +3,23 @@ import logging
 import logging.config
 import os
 import random
+import requests
 import subprocess
 import time
 import urllib
 import urllib.request
 
 import yaml
+
+
+def get_cluster_doc(sd_url, pw):
+    full_url = sd_url + "/admin/cluster"
+    logging.info("Trying to contact %s" % full_url)
+    r = requests.get(sd_url + "/admin/cluster", auth=('admin', pw))
+    if r.status_code != 200:
+        raise Exception("Unable to get the cluster document %d" % r.status_code)
+    return r.json()
+
 
 
 def get_meta_data(key):

--- a/aws/etc/terraform/instance/main.tf
+++ b/aws/etc/terraform/instance/main.tf
@@ -30,4 +30,3 @@ resource "aws_route" "internet_access" {
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.gw.id}"
 }
-

--- a/aws/etc/terraform/instance/stardog.tf
+++ b/aws/etc/terraform/instance/stardog.tf
@@ -17,6 +17,7 @@ data "template_file" "stardog_properties" {
 data "template_file" "stardog_userdata" {
   template = "${file("stardog_userdata.tpl")}"
   vars {
+    custom_script = "${file(var.custom_script)}"
     stardog_conf = "${data.template_file.stardog_properties.rendered}"
     custom_log4j_data = "${var.custom_log4j_data}"
     deployment_name = "${var.deployment_name}"

--- a/aws/etc/terraform/instance/stardog_userdata.tpl
+++ b/aws/etc/terraform/instance/stardog_userdata.tpl
@@ -33,6 +33,13 @@ while [ $rc -ne 0 ]; do
     /usr/local/bin/stardog-wait-for-socket 2 localhost:5821
     rc=$?
 done
-exit 0
+
+echo "Running the custom script..."
+CUSTOM_SCRIPT=/tmp/custom
+echo '${custom_script}' > $CUSTOM_SCRIPT
+chmod 755 $CUSTOM_SCRIPT
+$CUSTOM_SCRIPT
+echo "Done $?"
 
 date >> /tmp/boottime
+exit 0

--- a/aws/etc/terraform/instance/variables.tf
+++ b/aws/etc/terraform/instance/variables.tf
@@ -175,3 +175,9 @@ variable "root_volume_size" {
   description = "The size of the root partition"
   default = "16g"
 }
+
+variable "custom_script" {
+  type = "string"
+  description = "A custom script to execute on stardog nodes"
+  default = ""
+}

--- a/aws/etc/terraform/volumes/builder.tf
+++ b/aws/etc/terraform/volumes/builder.tf
@@ -98,7 +98,7 @@ resource "null_resource" "stardog_data" {
       "sudo mkfs -t ext4 /dev/xvdh",
       "sudo mkdir -p /mnt/data",
       "sudo mount /dev/xvdh /mnt/data",
-      "sudo mkdir -p /mnt/data/stardog-home",
+      "sudo mkdir -p /mnt/data/stardog-home/logs",
       "sudo chown -R ubuntu /mnt/data/"
     ]
   }

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ type CliContext struct {
 	ConsoleFile       string             `json:"-"`
 	ConsoleWriter     io.Writer          `json:"-"`
 	EnvList           []string           `json:"-"`
+	CustomExec        string             `json:"-"`
 	highlight         sdutils.ConsoleEffect
 	red               sdutils.ConsoleEffect
 	green             sdutils.ConsoleEffect
@@ -255,7 +256,9 @@ func (cliContext *CliContext) interactive(c *kingpin.ParseContext) error {
 		CustomLog4J:     cliContext.CustomLog4J,
 		Environment:     cliContext.EnvList,
 		DisableSecurity: cliContext.DisableSecurity,
+		CustomScript:    cliContext.CustomExec,
 	}
+	fmt.Println("XXX DDD " + baseD.CustomScript)
 	dep, err := sdutils.LoadDeployment(cliContext, &baseD, false)
 	if err != nil {
 		cliContext.ConsoleLog(1, "Creating the new deployment %s\n", cliContext.DeploymentName)
@@ -332,6 +335,7 @@ func (cliContext *CliContext) newDeployment(c *kingpin.ParseContext) error {
 		CustomLog4J:     cliContext.CustomLog4J,
 		Environment:     cliContext.EnvList,
 		DisableSecurity: cliContext.DisableSecurity,
+		CustomScript:    cliContext.CustomExec,
 	}
 	_, err = sdutils.LoadDeployment(cliContext, &baseD, true)
 	return err
@@ -731,6 +735,7 @@ func parseParameters(args []string) (*CliContext, error) {
 	cmdOpts.LaunchCmd.Flag("memory-max", "The maximum amount of memory to give the JVM that runs Stardog nodes.").StringVar(&cliContext.MemoryMax)
 	cmdOpts.LaunchCmd.Flag("memory-start", "The starting amount of memory to give the JVM that runs Stardog nodes.").StringVar(&cliContext.MemoryStart)
 	cmdOpts.LaunchCmd.Flag("disable-security", "Run the Stardog servers without security.").Default(fmt.Sprintf("%t", cliContext.DisableSecurity)).BoolVar(&cliContext.DisableSecurity)
+	cmdOpts.LaunchCmd.Flag("custom-exec", "A custom script to run on Stardog nodes (experimental).").StringVar(&cliContext.CustomExec)
 	cmdOpts.LaunchCmd.Validate(cliContext.envValidate)
 	cmdOpts.LaunchCmd.Action(cliContext.interactive)
 

--- a/sdutils/deployment.go
+++ b/sdutils/deployment.go
@@ -87,6 +87,10 @@ func LoadDeployment(context AppContext, baseD *BaseDeployment, new bool) (Deploy
 	}
 	os.MkdirAll(baseD.Directory, 0755)
 
+	if baseD.CustomScript != "" && !PathExists(baseD.CustomScript) {
+		return nil, fmt.Errorf("The path to the custom script %s does not exist", baseD.CustomScript)
+	}
+
 	d, err := plugin.DeploymentLoader(context, baseD, new)
 	return d, err
 }

--- a/sdutils/interfaces.go
+++ b/sdutils/interfaces.go
@@ -39,6 +39,7 @@ type BaseDeployment struct {
 	Environment     []string    `json:"environment,omitempty"`
 	DisableSecurity bool        `json:"disable_security,omitempty"`
 	CloudOpts       interface{} `json:"cloud_opts,omitempty"`
+	CustomScript    string      `json:"custom_script,omitempty"`
 }
 
 // AppContext provides and abstraction to logging, console interaction and


### PR DESCRIPTION
This adds an option that allows a user to supply a custom script to
run on all Stardog nodes.  Just the script itself is copied to the
remote machines thus any dependecies that it has must also be on that
machine.  This patch also adds /mnt/data/stardog-home/logs to the
recursive list of directories that are pulled down in the tarball
with the logs command.